### PR TITLE
Add WORKERS_IGNORE_APPS setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A simple background task worker that uses your Django database and admin for management. This
 project is meant for small to medium scale uses. If you need something more, check out Celery.
 
+
 ## Install
 
 Download the package
@@ -52,9 +53,10 @@ work on.
 python manage.py runworkers
 ```
 
+
 ## Scheduled tasks
 
-Sometimes you want to run a specific task every X seconds or at a later date. Thats what scheduled
+Sometimes you want to run a specific task every X seconds or at a later date. Thats what scheduled 
 tasks are for.
 
 ### Repeating scheduled tasks
@@ -79,7 +81,7 @@ def do_something_even_later():
 
 ### Date scheduled tasks
 
-Tasks can be scheduled to _run once_ at a later date by passing a `_schedule=<datetime>` argument
+Tasks can be scheduled to *run once* at a later date by passing a `_schedule=<datetime>` argument 
 when the task is called.
 
 ```python
@@ -105,7 +107,6 @@ You can optionally override these settings in your Django `settings.py` file:
 - `WORKERS_IGNORE_APPS` (default []) - Apps to ignore when searching settings.INSTALLED_APPS
 
 #### TODO (not working)
-
 - `WORKERS_TIMEOUT` (default 30) - Seconds a task can run before its killed
 - `WORKERS_RETRY` (default 3) - Number of retries before giving up
 - `WORKERS_CONCURRENCY` (default 1) - Number of worker processes to run

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A simple background task worker that uses your Django database and admin for management. This
 project is meant for small to medium scale uses. If you need something more, check out Celery.
 
-
 ## Install
 
 Download the package
@@ -53,10 +52,9 @@ work on.
 python manage.py runworkers
 ```
 
-
 ## Scheduled tasks
 
-Sometimes you want to run a specific task every X seconds or at a later date. Thats what scheduled 
+Sometimes you want to run a specific task every X seconds or at a later date. Thats what scheduled
 tasks are for.
 
 ### Repeating scheduled tasks
@@ -81,7 +79,7 @@ def do_something_even_later():
 
 ### Date scheduled tasks
 
-Tasks can be scheduled to *run once* at a later date by passing a `_schedule=<datetime>` argument 
+Tasks can be scheduled to _run once_ at a later date by passing a `_schedule=<datetime>` argument
 when the task is called.
 
 ```python
@@ -104,8 +102,10 @@ You can optionally override these settings in your Django `settings.py` file:
 
 - `WORKERS_SLEEP` (default 5) - Wait in seconds before checking for tasks, if none were found
 - `WORKERS_PURGE` (default 1,000) - How many recent task logs to keep in the admin
+- `WORKERS_IGNORE_APPS` (default []) - Apps to ignore when searching settings.INSTALLED_APPS
 
 #### TODO (not working)
+
 - `WORKERS_TIMEOUT` (default 30) - Seconds a task can run before its killed
 - `WORKERS_RETRY` (default 3) - Number of retries before giving up
 - `WORKERS_CONCURRENCY` (default 1) - Number of worker processes to run

--- a/workers/settings.py
+++ b/workers/settings.py
@@ -8,4 +8,4 @@ SLEEP = getattr(settings, 'WORKERS_SLEEP', 5)
 PURGE = getattr(settings, 'WORKERS_PURGE', 1000)
 
 # Which apps should we skip when looking for tasks.py?
-IGNORE_APPS = getattr(settings, 'WORKERS_IGNORE_APPS', '')
+IGNORE_APPS = getattr(settings, 'WORKERS_IGNORE_APPS', [])

--- a/workers/settings.py
+++ b/workers/settings.py
@@ -6,3 +6,6 @@ SLEEP = getattr(settings, 'WORKERS_SLEEP', 5)
 
 # How many logs to keep in admin
 PURGE = getattr(settings, 'WORKERS_PURGE', 1000)
+
+# Which apps should we skip when looking for tasks.py?
+IGNORE_APPS = getattr(settings, 'WORKERS_IGNORE_APPS', '')

--- a/workers/util.py
+++ b/workers/util.py
@@ -2,6 +2,7 @@ import logging
 
 from importlib import import_module
 
+
 log = logging.getLogger(__name__)
 
 
@@ -30,8 +31,7 @@ def autodiscover():
         except ImportError:
             continue
         except Exception as e:
-            log.error(
-                'failed to autodiscover {0}: does it have an __init__.py file?'.format(app))
+            log.error('failed to autodiscover {0}: does it have an __init__.py file?'.format(app))
             continue
 
         log.debug('discovered {0}.tasks'.format(app))

--- a/workers/util.py
+++ b/workers/util.py
@@ -2,7 +2,6 @@ import logging
 
 from importlib import import_module
 
-
 log = logging.getLogger(__name__)
 
 
@@ -13,8 +12,14 @@ def autodiscover():
     """
     import imp
     from django.conf import settings
+    from .settings import IGNORE_APPS
 
     for app in settings.INSTALLED_APPS:
+
+        # Skip apps specified in settings
+        if app in IGNORE_APPS:
+            continue
+
         try:
             app_path = import_module(app).__path__
         except (AttributeError, ImportError):
@@ -25,7 +30,8 @@ def autodiscover():
         except ImportError:
             continue
         except Exception as e:
-            log.error('failed to autodiscover {0}: does it have an __init__.py file?'.format(app))
+            log.error(
+                'failed to autodiscover {0}: does it have an __init__.py file?'.format(app))
             continue
 
         log.debug('discovered {0}.tasks'.format(app))


### PR DESCRIPTION
This change would add support for a `WORKERS_IGNORE_APPS` variable in the user's Django settings. This variable should be a list of strings. Apps named in this list will not be searched for a `tasks.py` file when executing `python manage.py runworkers`. This change shouldn't interfere with any existing functionality.

This will allow users to avoid conflicts if an installed package, e.g. from PyPI, is installed as an app and uses a `tasks.py` for its own background tasks. 

## Changes
- `settings.py` 
  Grab the `WORKERS_IGNORE_APPS` variable from the user's Django settings.
- `util.py`
  Import `WORKERS_IGNORE_APPS` and `continue` in the search loop if a match is found.
- `README.md`
  Describe the usage of the `WORKERS_IGNORE_APPS` setting.